### PR TITLE
added honeypot on contact page

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,7 +372,12 @@ app.post('/submit-career', (req, res) => {
 });
 
 app.post('/submit-contact', (req, res) => {
-  const { name, email, phone, message } = req.body
+  const { name, email, phone, honeypot, anotherhiddenfield, message } = req.body
+
+   // Check hidden fields for values (indicating spam)
+   if (honeypot || anotherhiddenfield) {
+    return res.status(400).send('Spam submission detected.');
+  }
 
   // Send email to admin
   const mailOptions = {

--- a/views/contact-us.handlebars
+++ b/views/contact-us.handlebars
@@ -89,6 +89,11 @@
                             <div class="form-group col-12">
                                 <input type="tel" name="phone" id="contact-phone" placeholder="Phone number">
                             </div>
+                            
+                              <!-- hidden fields to prevent $pam bOt-->
+                              <input type="text" name="honeypot" style="display: none;">
+                              <input type="text" name="anotherhiddenfield" style="display: none;">
+
                             <div class="form-group col-12">
                                 <textarea name="message" id="contact-message" cols="30" rows="4"
                                     placeholder="Your message"></textarea>


### PR DESCRIPTION
Added extra security (honeypot aka, hidden fields) to the Contact Us page to prevent spam bots as recaptcha is unable to prevent spam bot attacks on the contact us page.